### PR TITLE
fix: go version incompatible with AWS App Runner

### DIFF
--- a/cmd/event_dispatcher/main.go
+++ b/cmd/event_dispatcher/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"log/slog"
+	"log"
 	"net/http"
 
 	"github.com/srgssr/pillarbox-event-dispatcher/api/handler"
@@ -11,17 +11,8 @@ import (
 func main() {
 	// Command-line available flags
 	addr := flag.String("port", ":3569", "HTTP server port")
-	debug := flag.Bool("debug", false, "active debug logging, default value false")
 
 	flag.Parse()
-
-	// Set the debug mode if true
-	if *debug {
-		slog.SetLogLoggerLevel(slog.LevelDebug)
-		slog.Debug("Debug mode activated")
-	}
-
-	slog.Info("Server start", "PORT", *addr)
 
 	// HTTP request multiplexer
 	serveMux := http.NewServeMux()
@@ -31,15 +22,13 @@ func main() {
 		Handler: serveMux,
 	}
 
-	// Endpoint used by user to send data
-	serveMux.HandleFunc("POST /metrics", handler.PostMetrics)
-	// Endpoint used by clients to connect to the SSE and consume data
-	serveMux.HandleFunc("GET /metrics", handler.GetMetrics)
+	// Endpoint used by user to send data and consumers to receive data
+	serveMux.HandleFunc("/metrics", handler.Metrics)
 	// Endpoint to check the service health
-	serveMux.HandleFunc("GET /health", handler.Health)
+	serveMux.HandleFunc("/health", handler.Health)
 
 	// Run the HTTP server
 	if err := metricsServer.ListenAndServe(); err != nil {
-		slog.Error(err.Error())
+		log.Println(err.Error())
 	}
 }

--- a/pkg/sse/client.go
+++ b/pkg/sse/client.go
@@ -1,6 +1,7 @@
 package sse
 
 import (
+	"log"
 	"log/slog"
 	"sync"
 
@@ -18,7 +19,6 @@ func CreateClient() (string, eventChannel) {
 	defer clientMutex.Unlock()
 
 	clientId := uuid.NewString()
-	slog.Debug("Generate new client ID", "clientId", clientId)
 
 	if _, ok := clients[clientId]; !ok {
 		slog.Debug("Create new client", "clientId", clientId)
@@ -33,11 +33,9 @@ func CloseClient(clientId string) {
 	client, ok := clients[clientId]
 
 	if !ok {
-		slog.Warn("Try to close a client that doesn't exist", "clientId", clientId)
+		log.Println("Try to close a client that doesn't exist", "clientId", clientId)
 		return
 	}
-
-	slog.Debug("Close client with ID", "clientId", clientId)
 
 	close(client)
 	client = nil
@@ -49,8 +47,7 @@ func Broadcast(data string) {
 	clientMutex.Lock()
 	defer clientMutex.Unlock()
 
-	for id, client := range clients {
-		slog.Debug("Write data to client", "clientId", id)
+	for _, client := range clients {
 		client <- data
 	}
 }


### PR DESCRIPTION
## Description

The latest version of Go provided by AWS App Runner is 1.18.10, this causes the application to fail compilation. This is because the source code uses features available only in version >= 1.22.

## Changes made

- add an http handler to handle POST and GET requests
- remove slog
- remove the debug flag
- remove methods from http handler