### PR TITLE
fix(client): remove slog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/srgssr/pillarbox-event-dispatcher
 
-go 1.18.10
+go 1.18
 
 require github.com/google/uuid v1.6.0

--- a/pkg/sse/client.go
+++ b/pkg/sse/client.go
@@ -2,7 +2,6 @@ package sse
 
 import (
 	"log"
-	"log/slog"
 	"sync"
 
 	"github.com/google/uuid"
@@ -21,7 +20,6 @@ func CreateClient() (string, eventChannel) {
 	clientId := uuid.NewString()
 
 	if _, ok := clients[clientId]; !ok {
-		slog.Debug("Create new client", "clientId", clientId)
 		clients[clientId] = make(eventChannel)
 	}
 


### PR DESCRIPTION
## Description 

Removes a remaining `slog` and set the go.mod file to version 1.18.