### PR TITLE
feat(handler): event dispatcher url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ To send events from the player, use the URL:
 
 - `https://zdkimhgwhh.eu-central-1.awsapprunner.com/metrics`
 
+  Expects a `POST` request with a valid JSON payload
+
 To listen to events to feed any tool, use the URL:
 
-- `https://zdkimhgwhh.eu-central-1.awsapprunner.com/metrics`
+- `https://zdkimhgwhh.eu-central-1.awsapprunner.com/event-dispatcher`
 
 To check health status, use URL:
 
@@ -36,7 +38,7 @@ Once the installation completed, on your terminal, run the command below to star
 
 To receive data, you need to connect to the SSE server. To do this, in your terminal run:
 
-- `curl -n http://localhost:3569/metrics`
+- `curl -n http://localhost:3569/event-dispatcher`
 
 *You can create as many clients as you need by simply opening as many terminal tabs as you need and running the command shown above.*
 

--- a/cmd/event_dispatcher/main.go
+++ b/cmd/event_dispatcher/main.go
@@ -22,8 +22,10 @@ func main() {
 		Handler: serveMux,
 	}
 
-	// Endpoint used by user to send data and consumers to receive data
+	// Endpoint used by user to send data
 	serveMux.HandleFunc("/metrics", handler.Metrics)
+	// Endpoint used by clients to connect to the SSE and consume data
+	serveMux.HandleFunc("/event-dispatcher", handler.EventDispatcher)
 	// Endpoint to check the service health
 	serveMux.HandleFunc("/health", handler.Health)
 


### PR DESCRIPTION
## Description

Changes the URL path used to consume events to remove any ambiguity.

## Changes made

- creates the `event-dispatcher` HTTP route
- rename the `PostMetrics` handler to `Metrics` and restrict the type of requests accepted to `POST` only
- rename `GetMetrics` handler to `EventDispatcher` and restrict the type of requests accepted to `GET` only
- update README

**BREAKING CHANGE:** use the path `/event-dispatcher` to listen for events.