### PR TITLE
ci: add stable promotion workflow and dev deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Promote Version to Stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Enter the version to promote as stable (e.g., 1.0.0)"
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GH_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Pull the selected version of the image
+        run: |
+          docker pull ${{ env.ECR_REGISTRY }}/pillarbox-event-dispatcher:${{ github.event.inputs.version }}
+
+      - name: Tag the image as stable
+        run: |
+          docker tag ${{ env.ECR_REGISTRY }}/pillarbox-event-dispatcher:${{ github.event.inputs.version }} ${{ env.ECR_REGISTRY }}/pillarbox-event-dispatcher:stable
+          docker push ${{ env.ECR_REGISTRY }}/pillarbox-event-dispatcher:stable
+
+      - name: ECS deployment
+        run: >
+          aws ecs update-service \
+            --cluster pillarbox-monitoring-cluster \
+            --service dispatch-service \
+            --force-new-deployment \
+            --region ${{ secrets.AWS_REGION }} >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.semantic-release.outputs.version }}
+      version: ${{ steps.check-version.outputs.version }}
 
     permissions:
+      issues: write
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -46,7 +48,7 @@ jobs:
           npx semantic-release
 
       - name: Check version
-        id: check_version
+        id: check-version
         run: >
           if [ -f VERSION ]; then
             VERSION=$(cat VERSION)
@@ -57,7 +59,7 @@ jobs:
             echo "version=" >> $GITHUB_OUTPUT
           fi
 
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     needs: release
     if: needs.release.outputs.version != ''  # Skip deploy if no version is set
@@ -87,3 +89,24 @@ jobs:
           tags: |
             ${{ env.ECR_REGISTRY }}/pillarbox-event-dispatcher:${{ needs.release.outputs.version }}
             ${{ env.ECR_REGISTRY }}/pillarbox-event-dispatcher:latest
+
+  deploy-dev:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GH_DEV_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: ECS deployment
+        run: >
+          aws ecs update-service \
+            --cluster pillarbox-monitoring-cluster \
+            --service dispatch-service \
+            --force-new-deployment \
+            --region ${{ secrets.AWS_REGION }} >/dev/null

--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ sequenceDiagram
 
 ### Continuous Integration
 
-This project automates its development workflow using GitHub Actions across two main workflows:
-quality checks and releases.
+This project automates its own development workflow using GitHub Actions:
 
 1. **Quality Check for Pull Requests**
    Triggered on every pull request to the `main` branch, this workflow ensures the code passes
@@ -105,9 +104,15 @@ quality checks and releases.
    being merged into the main branch.
 
 2. **Release Workflow**
-   When changes are pushed to the `main` branch, this workflow handles versioning and releases using
+   When changes are pushed to `main`, this workflow handles versioning and releases with
    `semantic-release`. It automatically bumps the version, generates release notes, creates a tag,
-   and publishes a Docker image to an Amazon ECR repository.
+   and publishes a Docker image to Amazon ECR. This new version is automatically deployed to the
+   development environment.
+
+3. **Production deployment**
+   To deploy a specific version to production, manually trigger the `Promote Version to Stable`
+   workflow from the Actions tab, inputting the desired version number (e.g., 1.0.0). This workflow
+   tags the selected version as stable in the ECR, and forces a new deployment on ECS.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Introduces a new workflow for promoting specific image versions to stable in ECR, followed by an ECS update in production. It also adds an automatic deployment to the development environment after each release

## Changes Made

- Add workflow to tag images as stable in ECR and update ECS service in production.
- Add workflow for automatic deployment to dev after each release.
- Rename `deploy` job to `publish` in `release.yml` for clarity.
- Grant write permissions to issues and PRs in release job.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
