### PR TITLE
fix(event-receiver): options request were not allowed

### DIFF
--- a/api/handler/handlers.go
+++ b/api/handler/handlers.go
@@ -16,6 +16,13 @@ import (
 // This service acts as a passthrough, with the only check being the that the payload must be valid JSON.
 // If the payload is not a valid JSON, an error response is returned.
 func EventReceiver(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Allow", "POST, OPTIONS")
+		w.WriteHeader(http.StatusOK)
+
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "Not allowed", http.StatusMethodNotAllowed)
 		return


### PR DESCRIPTION



## Description

Fixes #15 by allowing OPTIONS HTTP method on the `/api/events` endpoint.

<!--
Please provide a brief summary of the changes made. Please explain why
this change was necessary. Was there a problem or an issue this change
will address? What will be improved with this change?
-->

## Changes Made

<!--
Please detail the modifications made. This could include areas such as
code, documentation, structure, or formatting.
-->

- return allow header on options request with value `POST` and `OPTIONS`

## Checklist

- [X] I have followed the project's style and contribution guidelines.
- [X] I have performed a self-review of my own changes.
- [X] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
